### PR TITLE
Add -d, -r and -c options to replace positional arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ SVGR provides the following commands:
 This command combines multiple SVG files into a single SVG, arranging the elements in a grid.
 
 ```
-svgr arrange:grid <source_directory> <rows> <columns> [options]
+svgr arrange:grid -d <source_directory> -r <rows> -c <columns> [options]
 ```
 
 Options:

--- a/lib/svgr/arrange/grid.rb
+++ b/lib/svgr/arrange/grid.rb
@@ -74,7 +74,7 @@ module Svgr
           rows = options[:rows].to_i
           columns = options[:columns].to_i
 
-          svg_files = Dir[File.join(options[:directory], "*.svg")]
+          svg_files = Dir[File.join(options[:directory], "*.svg")][0..rows*columns]
 
           combined_elements =
             svg_files.flat_map do |file|

--- a/lib/svgr/arrange/grid.rb
+++ b/lib/svgr/arrange/grid.rb
@@ -12,6 +12,9 @@ module Svgr
             scaling_factor: 1,
             margin_top: 0,
             margin_left: 0,
+            rows: 1,
+            columns: 1,
+            directory: Dir.pwd
           }
 
           opt_parser =
@@ -40,6 +43,27 @@ module Svgr
                 "Left margin between the SVG elements",
               ) { |l| options[:margin_left] = l }
 
+              opts.on(
+                "-d",
+                "--directory DIRECTORY",
+                String,
+                "Directory where .svg files are located",
+              ) { |d| options[:directory] = d }
+
+              opts.on(
+                "-r",
+                "--rows ROWS",
+                Integer,
+                "Number of rows to use",
+              ) { |r| options[:rows] = r }
+
+              opts.on(
+                "-c",
+                "--columns COLUMNS",
+                Integer,
+                "Number of columns to use",
+              ){ |c| options[:columns] = c }
+
               opts.on("-h", "--help", "Prints this help") do
                 puts opts
                 exit
@@ -47,15 +71,10 @@ module Svgr
             end
           opt_parser.parse!(argv)
 
-          if argv.length < 3
-            puts opt_parser.help
-            exit(1)
-          end
+          rows = options[:rows].to_i
+          columns = options[:columns].to_i
 
-          file_paths, rows, columns = argv.shift(3)
-          rows = rows.to_i
-          columns = columns.to_i
-          svg_files = file_paths.split(",")[0...rows * columns]
+          svg_files = Dir[File.join(options[:directory], "*.svg")]
 
           combined_elements =
             svg_files.flat_map do |file|
@@ -65,8 +84,8 @@ module Svgr
 
           combined_svg = create_combined_svg(
             combined_elements,
-            rows,
-            columns,
+            options[:rows],
+            options[:columns],
             options[:scaling_factor],
             margin: { top: options[:margin_top], left: options[:margin_left] },
           )

--- a/spec/svgr/arrange/grid_spec.rb
+++ b/spec/svgr/arrange/grid_spec.rb
@@ -10,8 +10,9 @@ RSpec.describe(Svgr::Arrange::Grid) do
     let(:rows) { 1 }
     let(:columns) { 3 }
     let(:file_paths) { Dir.glob(File.join(fixtures_path, "*.svg")).first(3).join(",") }
-    let(:argv) { [file_paths, rows, columns] }
     let(:output) { capture_stdout { described_class.start(argv) } }
+
+    let(:argv) {["-r", rows.to_s, "-c", columns.to_s, "-d", fixtures_path]}
 
     it "combines the specified number of SVGs" do
       doc = Nokogiri.XML(output)
@@ -25,13 +26,16 @@ RSpec.describe(Svgr::Arrange::Grid) do
       let(:margin_left) { 20 }
       let(:argv) do
         [
-          file_paths,
-          rows.to_s,
-          columns.to_s,
           "--margin-top",
           margin_top.to_s,
           "--margin-left",
           margin_left.to_s,
+          "--rows",
+          rows.to_s,
+          "--columns",
+          columns.to_s,
+          "--directory",
+          fixtures_path
         ]
       end
 


### PR DESCRIPTION
After experiencing https://github.com/nassredean/svgr/issues/3 I decided to fix it by replacing the positional arguments with more switches. Specifically it now uses:

* -d/--directory for the directory name (default: pwd)
* -c/--columns for the number of columns (default: 1)
* -r/--rows for the number of rows (default: 1)

The command now works (although the code doesn't, but that's another PR).
